### PR TITLE
Derive `Debug` and `PartialEq` for NodeMut and related objects.

### DIFF
--- a/src/core_tree.rs
+++ b/src/core_tree.rs
@@ -9,6 +9,7 @@ use error::NodeIdError;
 ///
 /// Groups a collection of Node<T>s with a process unique id.
 ///
+#[derive(Debug, PartialEq)]
 pub(crate) struct CoreTree<T> {
     id: ProcessUniqueId,
     slab: slab::Slab<Node<T>>,

--- a/src/core_tree.rs
+++ b/src/core_tree.rs
@@ -1,8 +1,8 @@
-use snowflake::ProcessUniqueId;
-use slab;
-use node::Node;
-use NodeId;
 use error::NodeIdError;
+use node::Node;
+use slab;
+use snowflake::ProcessUniqueId;
+use NodeId;
 
 ///
 /// A wrapper around a Slab containing Node<T> values.
@@ -127,7 +127,7 @@ mod tests {
         let tree2: CoreTree<i32> = CoreTree::new(0);
 
         let mut id = tree.insert(1);
-        id.tree_id = tree2.id;  // oops, wrong tree id.
+        id.tree_id = tree2.id; // oops, wrong tree id.
 
         let result = tree.get(id);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,19 +2,19 @@
 
 extern crate snowflake;
 
-mod slab;
 mod core_tree;
 pub mod error;
 pub mod iter;
 pub mod node;
+mod slab;
 pub mod tree;
 
-pub use tree::Tree;
-pub use node::NodeRef;
-pub use node::NodeMut;
 pub use iter::Ancestors;
 pub use iter::NextSiblings;
+pub use node::NodeMut;
+pub use node::NodeRef;
 use snowflake::ProcessUniqueId;
+pub use tree::Tree;
 
 ///
 /// An identifier used to differentiate between Nodes and tie

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -6,7 +6,7 @@ pub use self::node_ref::NodeRef;
 
 use NodeId;
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub(crate) struct Relatives {
     pub(crate) parent: Option<NodeId>,
     pub(crate) prev_sibling: Option<NodeId>,
@@ -15,6 +15,7 @@ pub(crate) struct Relatives {
     pub(crate) last_child: Option<NodeId>,
 }
 
+#[derive(Debug, PartialEq)]
 pub(crate) struct Node<T> {
     pub(crate) data: T,
     pub(crate) relatives: Relatives,

--- a/src/node/node_mut.rs
+++ b/src/node/node_mut.rs
@@ -5,6 +5,7 @@ use NodeId;
 ///
 /// A mutable reference to a given `Node`'s data and its relatives.
 ///
+#[derive(Debug, PartialEq)]
 pub struct NodeMut<'a, T: 'a> {
     pub(crate) node_id: NodeId,
     pub(crate) tree: &'a mut Tree<T>,

--- a/src/node/node_ref.rs
+++ b/src/node/node_ref.rs
@@ -255,12 +255,7 @@ mod node_ref_tests {
         let node_id;
         {
             let mut root_mut = tree.root_mut();
-            node_id = root_mut
-                .append(2)
-                .append(3)
-                .append(4)
-                .append(5)
-                .node_id();
+            node_id = root_mut.append(2).append(3).append(4).append(5).node_id();
         }
         let tree = tree;
 

--- a/src/slab.rs
+++ b/src/slab.rs
@@ -39,10 +39,7 @@ impl<T> Slab<T> {
         };
 
         if let Some(index) = self.first_free_slot {
-            match mem::replace(
-                &mut self.data[index],
-                new_slot
-            ) {
+            match mem::replace(&mut self.data[index], new_slot) {
                 Slot::Empty { next_free_slot } => {
                     self.first_free_slot = next_free_slot;
                 }
@@ -70,7 +67,7 @@ impl<T> Slab<T> {
         let slot = mem::replace(
             &mut self.data[index.index],
             Slot::Empty {
-                next_free_slot: self.first_free_slot
+                next_free_slot: self.first_free_slot,
             },
         );
 
@@ -84,8 +81,8 @@ impl<T> Slab<T> {
                     self.data[index.index] = Slot::Filled { item, generation };
                     None
                 }
-            },
-            s =>  {
+            }
+            s => {
                 self.data[index.index] = s;
                 None
             }
@@ -93,33 +90,27 @@ impl<T> Slab<T> {
     }
 
     pub(super) fn get(&self, index: Index) -> Option<&T> {
-        self.data.get(index.index)
-            .and_then(|slot| {
-                match slot {
-                    Slot::Filled { item, generation } => {
-                        if index.generation == *generation {
-                            return Some(item);
-                        }
-                        None
-                    },
-                    _ => None,
+        self.data.get(index.index).and_then(|slot| match slot {
+            Slot::Filled { item, generation } => {
+                if index.generation == *generation {
+                    return Some(item);
                 }
-            })
+                None
+            }
+            _ => None,
+        })
     }
 
     pub(super) fn get_mut(&mut self, index: Index) -> Option<&mut T> {
-        self.data.get_mut(index.index)
-            .and_then(|slot| {
-                match slot {
-                    Slot::Filled { item, generation } => {
-                        if index.generation == *generation {
-                            return Some(item);
-                        }
-                        None
-                    },
-                    _ => None,
+        self.data.get_mut(index.index).and_then(|slot| match slot {
+            Slot::Filled { item, generation } => {
+                if index.generation == *generation {
+                    return Some(item);
                 }
-            })
+                None
+            }
+            _ => None,
+        })
     }
 }
 

--- a/src/slab.rs
+++ b/src/slab.rs
@@ -6,12 +6,13 @@ pub(super) struct Index {
     generation: u64,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 enum Slot<T> {
     Empty { next_free_slot: Option<usize> },
     Filled { item: T, generation: u64 },
 }
 
+#[derive(Debug, PartialEq)]
 pub(super) struct Slab<T> {
     data: Vec<Slot<T>>,
     first_free_slot: Option<usize>,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,11 +1,12 @@
 use core_tree::CoreTree;
+use error::NodeIdError;
 use node::*;
 use NodeId;
-use error::NodeIdError;
 
 ///
 /// A tree structure containing `Node`s.
 ///
+#[derive(Debug, PartialEq)]
 pub struct Tree<T> {
     pub(crate) root_id: NodeId,
     pub(crate) core_tree: CoreTree<T>,


### PR DESCRIPTION
Deriving such traits allow users to do `assert_eq!()` with crate's object.
I also ran `cargo fmt` which formated previous code too.

Feel free to discuss if you have any question.