### PR TITLE
allow creation of empty trees

### DIFF
--- a/src/node/node_mut.rs
+++ b/src/node/node_mut.rs
@@ -1,6 +1,9 @@
 use crate::node::Node;
+use crate::node::NodeRef;
 use crate::tree::Tree;
 use crate::NodeId;
+
+//todo: document this
 
 ///
 /// A mutable reference to a given `Node`'s data and its relatives.
@@ -141,6 +144,10 @@ impl<'a, T> NodeMut<'a, T> {
         self.tree.core_tree.remove(last_id)
     }
 
+    pub fn as_ref(&self) -> NodeRef<T> {
+        NodeRef::new(self.node_id, self.tree)
+    }
+
     fn get_self_as_node(&self) -> &Node<T> {
         if let Some(node) = self.tree.get_node(self.node_id) {
             &node
@@ -157,8 +164,9 @@ mod node_mut_tests {
 
     #[test]
     fn node_id() {
-        let mut tree = Tree::new(1);
-        let root_id = tree.root_id();
+        let mut tree = Tree::new();
+        tree.set_root(1);
+        let root_id = tree.root_id().expect("root doesn't exist?");
 
         let root_mut = tree.get_mut(root_id).unwrap();
         assert_eq!(root_id, root_mut.node_id());
@@ -166,8 +174,9 @@ mod node_mut_tests {
 
     #[test]
     fn data() {
-        let mut tree = Tree::new(1);
-        let root_id = tree.root_id();
+        let mut tree = Tree::new();
+        tree.set_root(1);
+        let root_id = tree.root_id().expect("root doesn't exist?");
 
         let mut root_mut = tree.get_mut(root_id).unwrap();
         assert_eq!(root_mut.data(), &mut 1);
@@ -178,48 +187,54 @@ mod node_mut_tests {
 
     #[test]
     fn parent() {
-        let mut tree = Tree::new(1);
-        let root_id = tree.root_id();
+        let mut tree = Tree::new();
+        tree.set_root(1);
+        let root_id = tree.root_id().expect("root doesn't exist?");
         let mut root_mut = tree.get_mut(root_id).unwrap();
         assert!(root_mut.parent().is_none());
     }
 
     #[test]
     fn prev_sibling() {
-        let mut tree = Tree::new(1);
-        let root_id = tree.root_id();
+        let mut tree = Tree::new();
+        tree.set_root(1);
+        let root_id = tree.root_id().expect("root doesn't exist?");
         let mut root_mut = tree.get_mut(root_id).unwrap();
         assert!(root_mut.prev_sibling().is_none());
     }
 
     #[test]
     fn next_sibling() {
-        let mut tree = Tree::new(1);
-        let root_id = tree.root_id();
+        let mut tree = Tree::new();
+        tree.set_root(1);
+        let root_id = tree.root_id().expect("root doesn't exist?");
         let mut root_mut = tree.get_mut(root_id).unwrap();
         assert!(root_mut.next_sibling().is_none());
     }
 
     #[test]
     fn first_child() {
-        let mut tree = Tree::new(1);
-        let root_id = tree.root_id();
+        let mut tree = Tree::new();
+        tree.set_root(1);
+        let root_id = tree.root_id().expect("root doesn't exist?");
         let mut root_mut = tree.get_mut(root_id).unwrap();
         assert!(root_mut.first_child().is_none());
     }
 
     #[test]
     fn last_child() {
-        let mut tree = Tree::new(1);
-        let root_id = tree.root_id();
+        let mut tree = Tree::new();
+        tree.set_root(1);
+        let root_id = tree.root_id().expect("root doesn't exist?");
         let mut root_mut = tree.get_mut(root_id).unwrap();
         assert!(root_mut.last_child().is_none());
     }
 
     #[test]
     fn append_no_children_present() {
-        let mut tree = Tree::new(1);
-        let root_id = tree.root_id();
+        let mut tree = Tree::new();
+        tree.set_root(1);
+        let root_id = tree.root_id().expect("root doesn't exist?");
 
         let mut root_mut = tree.get_mut(root_id).unwrap();
         let new_id = root_mut.append(2).node_id();
@@ -250,8 +265,9 @@ mod node_mut_tests {
 
     #[test]
     fn append_single_child_present() {
-        let mut tree = Tree::new(1);
-        let root_id = tree.root_id();
+        let mut tree = Tree::new();
+        tree.set_root(1);
+        let root_id = tree.root_id().expect("root doesn't exist?");
 
         let mut root_mut = tree.get_mut(root_id).unwrap();
         let new_id = root_mut.append(2).node_id();
@@ -296,8 +312,9 @@ mod node_mut_tests {
 
     #[test]
     fn append_two_children_present() {
-        let mut tree = Tree::new(1);
-        let root_id = tree.root_id();
+        let mut tree = Tree::new();
+        tree.set_root(1);
+        let root_id = tree.root_id().expect("root doesn't exist?");
 
         let mut root_mut = tree.get_mut(root_id).unwrap();
         let new_id = root_mut.append(2).node_id();
@@ -363,8 +380,9 @@ mod node_mut_tests {
 
     #[test]
     fn prepend_no_children_present() {
-        let mut tree = Tree::new(1);
-        let root_id = tree.root_id();
+        let mut tree = Tree::new();
+        tree.set_root(1);
+        let root_id = tree.root_id().expect("root doesn't exist?");
 
         let mut root_mut = tree.get_mut(root_id).unwrap();
         let new_id = root_mut.prepend(2).node_id();
@@ -395,8 +413,9 @@ mod node_mut_tests {
 
     #[test]
     fn prepend_single_child_present() {
-        let mut tree = Tree::new(1);
-        let root_id = tree.root_id();
+        let mut tree = Tree::new();
+        tree.set_root(1);
+        let root_id = tree.root_id().expect("root doesn't exist?");
 
         let mut root_mut = tree.get_mut(root_id).unwrap();
         let new_id = root_mut.prepend(2).node_id();
@@ -441,8 +460,9 @@ mod node_mut_tests {
 
     #[test]
     fn prepend_two_children_present() {
-        let mut tree = Tree::new(1);
-        let root_id = tree.root_id();
+        let mut tree = Tree::new();
+        tree.set_root(1);
+        let root_id = tree.root_id().expect("root doesn't exist?");
 
         let mut root_mut = tree.get_mut(root_id).unwrap();
         let new_id = root_mut.prepend(2).node_id();
@@ -508,8 +528,9 @@ mod node_mut_tests {
 
     #[test]
     fn remove_first_no_children_present() {
-        let mut tree = Tree::new(1);
-        let root_id = tree.root_id();
+        let mut tree = Tree::new();
+        tree.set_root(1);
+        let root_id = tree.root_id().expect("root doesn't exist?");
 
         let mut root_mut = tree.get_mut(root_id).unwrap();
         let first_child_data = root_mut.remove_first();
@@ -525,8 +546,9 @@ mod node_mut_tests {
 
     #[test]
     fn remove_first_single_child_present() {
-        let mut tree = Tree::new(1);
-        let root_id = tree.root_id();
+        let mut tree = Tree::new();
+        tree.set_root(1);
+        let root_id = tree.root_id().expect("root doesn't exist?");
 
         let mut root_mut = tree.get_mut(root_id).unwrap();
         root_mut.append(2);
@@ -543,8 +565,9 @@ mod node_mut_tests {
 
     #[test]
     fn remove_first_two_children_present() {
-        let mut tree = Tree::new(1);
-        let root_id = tree.root_id();
+        let mut tree = Tree::new();
+        tree.set_root(1);
+        let root_id = tree.root_id().expect("root doesn't exist?");
 
         let mut root_mut = tree.get_mut(root_id).unwrap();
         root_mut.append(2);
@@ -573,8 +596,9 @@ mod node_mut_tests {
 
     #[test]
     fn remove_first_three_children_present() {
-        let mut tree = Tree::new(1);
-        let root_id = tree.root_id();
+        let mut tree = Tree::new();
+        tree.set_root(1);
+        let root_id = tree.root_id().expect("root doesn't exist?");
 
         let mut root_mut = tree.get_mut(root_id).unwrap();
         root_mut.append(2);
@@ -614,8 +638,9 @@ mod node_mut_tests {
 
     #[test]
     fn remove_last_no_children_present() {
-        let mut tree = Tree::new(1);
-        let root_id = tree.root_id();
+        let mut tree = Tree::new();
+        tree.set_root(1);
+        let root_id = tree.root_id().expect("root doesn't exist?");
 
         let mut root_mut = tree.get_mut(root_id).unwrap();
         let last_child_data = root_mut.remove_last();
@@ -631,8 +656,9 @@ mod node_mut_tests {
 
     #[test]
     fn remove_last_single_child_present() {
-        let mut tree = Tree::new(1);
-        let root_id = tree.root_id();
+        let mut tree = Tree::new();
+        tree.set_root(1);
+        let root_id = tree.root_id().expect("root doesn't exist?");
 
         let mut root_mut = tree.get_mut(root_id).unwrap();
         root_mut.append(2);
@@ -649,8 +675,9 @@ mod node_mut_tests {
 
     #[test]
     fn remove_last_two_children_present() {
-        let mut tree = Tree::new(1);
-        let root_id = tree.root_id();
+        let mut tree = Tree::new();
+        tree.set_root(1);
+        let root_id = tree.root_id().expect("root doesn't exist?");
 
         let mut root_mut = tree.get_mut(root_id).unwrap();
         let node_id = root_mut.append(2).node_id();
@@ -679,8 +706,9 @@ mod node_mut_tests {
 
     #[test]
     fn remove_last_three_children_present() {
-        let mut tree = Tree::new(1);
-        let root_id = tree.root_id();
+        let mut tree = Tree::new();
+        tree.set_root(1);
+        let root_id = tree.root_id().expect("root doesn't exist?");
 
         let mut root_mut = tree.get_mut(root_id).unwrap();
         let node_id = root_mut.append(2).node_id();

--- a/src/node/node_ref.rs
+++ b/src/node/node_ref.rs
@@ -23,8 +23,9 @@ impl<'a, T> NodeRef<'a, T> {
     /// ```
     /// use slab_tree::tree::Tree;
     ///
-    /// let tree = Tree::new(1);
-    /// let root = tree.root();
+    /// let mut tree = Tree::new();
+    /// tree.set_root(1);
+    /// let root = tree.root().expect("root doesn't exist?");
     ///
     /// assert_eq!(root.data(), &1);
     /// ```
@@ -44,8 +45,9 @@ impl<'a, T> NodeRef<'a, T> {
     /// ```
     /// use slab_tree::tree::Tree;
     ///
-    /// let tree = Tree::new(1);
-    /// let root = tree.root();
+    /// let mut tree = Tree::new();
+    /// tree.set_root(1);
+    /// let root = tree.root().expect("root doesn't exist?");
     ///
     /// assert!(root.parent().is_none());
     /// ```
@@ -64,8 +66,9 @@ impl<'a, T> NodeRef<'a, T> {
     /// ```
     /// use slab_tree::tree::Tree;
     ///
-    /// let tree = Tree::new(1);
-    /// let root = tree.root();
+    /// let mut tree = Tree::new();
+    /// tree.set_root(1);
+    /// let root = tree.root().expect("root doesn't exist?");
     ///
     /// assert!(root.prev_sibling().is_none());
     /// ```
@@ -84,8 +87,9 @@ impl<'a, T> NodeRef<'a, T> {
     /// ```
     /// use slab_tree::tree::Tree;
     ///
-    /// let tree = Tree::new(1);
-    /// let root = tree.root();
+    /// let mut tree = Tree::new();
+    /// tree.set_root(1);
+    /// let root = tree.root().expect("root doesn't exist?");
     ///
     /// assert!(root.next_sibling().is_none());
     /// ```
@@ -104,8 +108,9 @@ impl<'a, T> NodeRef<'a, T> {
     /// ```
     /// use slab_tree::tree::Tree;
     ///
-    /// let tree = Tree::new(1);
-    /// let root = tree.root();
+    /// let mut tree = Tree::new();
+    /// tree.set_root(1);
+    /// let root = tree.root().expect("root doesn't exist?");
     ///
     /// assert!(root.first_child().is_none());
     /// ```
@@ -124,8 +129,9 @@ impl<'a, T> NodeRef<'a, T> {
     /// ```
     /// use slab_tree::tree::Tree;
     ///
-    /// let tree = Tree::new(1);
-    /// let root = tree.root();
+    /// let mut tree = Tree::new();
+    /// tree.set_root(1);
+    /// let root = tree.root().expect("root doesn't exist?");
     ///
     /// assert!(root.last_child().is_none());
     /// ```
@@ -144,9 +150,10 @@ impl<'a, T> NodeRef<'a, T> {
     /// ```
     /// use slab_tree::tree::Tree;
     ///
-    /// let mut tree = Tree::new(1);
+    /// let mut tree = Tree::new();
+    /// tree.set_root(1);
     ///
-    /// let leaf_id = tree.root_mut()
+    /// let leaf_id = tree.root_mut().expect("root doesn't exist?")
     ///     .append(2)
     ///     .append(3)
     ///     .append(4)
@@ -171,14 +178,15 @@ impl<'a, T> NodeRef<'a, T> {
     /// ```
     /// use slab_tree::tree::Tree;
     ///
-    /// let mut tree = Tree::new(1);
-    /// {
-    ///     let mut root = tree.root_mut();
-    ///     root.append(2);
-    ///     root.append(3);
-    ///     root.append(4);
-    /// }
-    /// let root = tree.root();
+    /// let mut tree = Tree::new();
+    /// tree.set_root(1);
+    ///
+    /// let mut root = tree.root_mut().expect("root doesn't exist?");
+    /// root.append(2);
+    /// root.append(3);
+    /// root.append(4);
+    ///
+    /// let root = root.as_ref();
     ///
     /// let values = [2, 3, 4];
     /// for (i, child) in root.children().enumerate() {
@@ -207,57 +215,64 @@ mod node_ref_tests {
 
     #[test]
     fn data() {
-        let tree = Tree::new(1);
-        let root_id = tree.root_id();
+        let mut tree = Tree::new();
+        tree.set_root(1);
+        let root_id = tree.root_id().expect("root doesn't exist?");
         let root_ref = tree.get(root_id).unwrap();
         assert_eq!(root_ref.data(), &1);
     }
 
     #[test]
     fn parent() {
-        let tree = Tree::new(1);
-        let root_id = tree.root_id();
+        let mut tree = Tree::new();
+        tree.set_root(1);
+        let root_id = tree.root_id().expect("root doesn't exist?");
         let root_ref = tree.get(root_id).unwrap();
         assert!(root_ref.parent().is_none());
     }
 
     #[test]
     fn prev_sibling() {
-        let tree = Tree::new(1);
-        let root_id = tree.root_id();
+        let mut tree = Tree::new();
+        tree.set_root(1);
+        let root_id = tree.root_id().expect("root doesn't exist?");
         let root_ref = tree.get(root_id).unwrap();
         assert!(root_ref.prev_sibling().is_none());
     }
 
     #[test]
     fn next_sibling() {
-        let tree = Tree::new(1);
-        let root_id = tree.root_id();
+        let mut tree = Tree::new();
+        tree.set_root(1);
+        let root_id = tree.root_id().expect("root doesn't exist?");
         let root_ref = tree.get(root_id).unwrap();
         assert!(root_ref.next_sibling().is_none());
     }
 
     #[test]
     fn first_child() {
-        let tree = Tree::new(1);
-        let root_id = tree.root_id();
+        let mut tree = Tree::new();
+        tree.set_root(1);
+        let root_id = tree.root_id().expect("root doesn't exist?");
         let root_ref = tree.get(root_id).unwrap();
         assert!(root_ref.first_child().is_none());
     }
 
     #[test]
     fn last_child() {
-        let tree = Tree::new(1);
-        let root_id = tree.root_id();
+        let mut tree = Tree::new();
+        tree.set_root(1);
+        let root_id = tree.root_id().expect("root doesn't exist?");
         let root_ref = tree.get(root_id).unwrap();
         assert!(root_ref.last_child().is_none());
     }
 
     #[test]
     fn ancestors() {
-        let mut tree = Tree::new(1);
+        let mut tree = Tree::new();
+        tree.set_root(1);
 
-        let mut root_mut = tree.root_mut();
+        let mut root_mut = tree.root_mut().expect("root doesn't exist");
         let node_id = root_mut.append(2).append(3).append(4).append(5).node_id();
 
         let values = [4, 3, 2, 1];
@@ -270,16 +285,17 @@ mod node_ref_tests {
 
     #[test]
     fn children() {
-        let mut tree = Tree::new(1);
+        let mut tree = Tree::new();
+        tree.set_root(1);
 
-        let mut root_mut = tree.root_mut();
-        root_mut.append(2);
-        root_mut.append(3);
-        root_mut.append(4);
-        root_mut.append(5);
+        let mut root = tree.root_mut().expect("root doesn't exist");
+        root.append(2);
+        root.append(3);
+        root.append(4);
+        root.append(5);
 
         let values = [2, 3, 4, 5];
-        let root = tree.root();
+        let root = root.as_ref();
 
         for (i, node_ref) in root.children().enumerate() {
             assert_eq!(node_ref.data(), &values[i]);


### PR DESCRIPTION
Added a `TreeBuilder` to make building `Trees` easier.
Made several API tweaks to `Tree` because having a root node is no-
longer guaranteed.