### PR TITLE
add tree.write_formatted(), example

### DIFF
--- a/examples/formatted.rs
+++ b/examples/formatted.rs
@@ -1,0 +1,34 @@
+extern crate slab_tree;
+
+use slab_tree::*;
+
+fn main() {
+    let mut tree = TreeBuilder::new().with_root(0).build();
+    let mut root = tree.root_mut().unwrap();
+    {
+        let mut one = root.append(1);
+        let mut two = one.append(2);
+        two.append(3);
+        two.append(4);
+    }
+    {
+        let mut five = root.append(5);
+        five.append(6).append(7);
+        five.append(8);
+    }
+    root.append(9);
+
+    let mut s = String::new();
+    // 0
+    // ├── 1
+    // │   └── 2
+    // │       ├── 3
+    // │       └── 4
+    // ├── 5
+    // │   ├── 6
+    // │   │   └── 7
+    // │   └── 8
+    // └── 9
+    tree.write_formatted(&mut s).unwrap();
+    print!("{}", s);
+}

--- a/src/node/node_ref.rs
+++ b/src/node/node_ref.rs
@@ -18,6 +18,25 @@ impl<'a, T> NodeRef<'a, T> {
     }
 
     ///
+    /// Returns the `NodeId` that identifies this `Node` in the tree.
+    ///
+    /// ```
+    /// use slab_tree::tree::TreeBuilder;
+    ///
+    /// let mut tree = TreeBuilder::new().with_root(1).build();
+    /// let root_id = tree.root_id().expect("root doesn't exist?");
+    /// let root = tree.root_mut().expect("root doesn't exist?");
+    ///
+    /// let root_id_again = root.node_id();
+    ///
+    /// assert_eq!(root_id_again, root_id);
+    /// ```
+    ///
+    pub fn node_id(&self) -> NodeId {
+        self.node_id
+    }
+
+    ///
     /// Returns a reference to the data contained by the given `Node`.
     ///
     /// ```


### PR DESCRIPTION
Writes a visual representation of a tree with appearance based on the [`tree`](http://mama.indstate.edu/users/ice/tree/) command.