### PR TITLE
Reorder siblings

### DIFF
--- a/src/node/node_mut.rs
+++ b/src/node/node_mut.rs
@@ -382,16 +382,40 @@ impl<'a, T> NodeMut<'a, T> {
     ///     tree.root().unwrap().children().map(|child_ref| *child_ref.data())
     ///         .collect::<Vec<i32>>(),
     ///     vec![3, 2, 4]);
+    /// assert_eq!(
+    ///     *tree.get(two_id).unwrap().parent().unwrap().first_child().unwrap()
+    ///         .data(),
+    ///     3);
+    /// assert_eq!(
+    ///     *tree.get(two_id).unwrap().parent().unwrap().last_child().unwrap()
+    ///         .data(),
+    ///     4);
     /// assert!(tree.get_mut(two_id).unwrap().swap_next_sibling());
     /// assert_eq!(
     ///   tree.root().unwrap().children().map(|child_ref| *child_ref.data())
     ///         .collect::<Vec<i32>>(),
     ///     vec![3, 4, 2]);
+    /// assert_eq!(
+    ///     *tree.get(two_id).unwrap().parent().unwrap().first_child().unwrap()
+    ///         .data(),
+    ///     3);
+    /// assert_eq!(
+    ///     *tree.get(two_id).unwrap().parent().unwrap().last_child().unwrap()
+    ///         .data(),
+    ///     2);
     /// assert!(!tree.get_mut(two_id).unwrap().swap_next_sibling());
     /// assert_eq!(
     ///     tree.root().unwrap().children().map(|child_ref| *child_ref.data())
     ///         .collect::<Vec<i32>>(),
     ///     vec![3, 4, 2]);
+    /// assert_eq!(
+    ///     *tree.get(two_id).unwrap().parent().unwrap().first_child().unwrap()
+    ///         .data(),
+    ///     3);
+    /// assert_eq!(
+    ///     *tree.get(two_id).unwrap().parent().unwrap().last_child().unwrap()
+    ///         .data(),
+    ///     2);
     /// ```
     pub fn swap_next_sibling(&mut self) -> bool {
         let node_id = self.node_id();
@@ -454,16 +478,40 @@ impl<'a, T> NodeMut<'a, T> {
     ///     tree.root().unwrap().children().map(|child_ref| *child_ref.data())
     ///         .collect::<Vec<i32>>(),
     ///     vec![2, 4, 3]);
+    /// assert_eq!(
+    ///     *tree.get(four_id).unwrap().parent().unwrap().first_child().unwrap()
+    ///         .data(),
+    ///     2);
+    /// assert_eq!(
+    ///     *tree.get(four_id).unwrap().parent().unwrap().last_child().unwrap()
+    ///         .data(),
+    ///     3);
     /// assert!(tree.get_mut(four_id).unwrap().swap_prev_sibling());
     /// assert_eq!(
     ///     tree.root().unwrap().children().map(|child_ref| *child_ref.data())
     ///         .collect::<Vec<i32>>(),
     ///     vec![4, 2, 3]);
+    /// assert_eq!(
+    ///     *tree.get(four_id).unwrap().parent().unwrap().first_child().unwrap()
+    ///         .data(),
+    ///     4);
+    /// assert_eq!(
+    ///     *tree.get(four_id).unwrap().parent().unwrap().last_child().unwrap()
+    ///         .data(),
+    ///     3);
     /// assert!(!tree.get_mut(four_id).unwrap().swap_prev_sibling());
     /// assert_eq!(
     ///     tree.root().unwrap().children().map(|child_ref| *child_ref.data())
     ///         .collect::<Vec<i32>>(),
     ///     vec![4, 2, 3]);
+    /// assert_eq!(
+    ///     *tree.get(four_id).unwrap().parent().unwrap().first_child().unwrap()
+    ///         .data(),
+    ///     4);
+    /// assert_eq!(
+    ///     *tree.get(four_id).unwrap().parent().unwrap().last_child().unwrap()
+    ///         .data(),
+    ///     3);
     /// ```
     pub fn swap_prev_sibling(&mut self) -> bool {
         let node_id = self.node_id();
@@ -525,11 +573,27 @@ impl<'a, T> NodeMut<'a, T> {
     ///     tree.root().unwrap().children().map(|child_ref| *child_ref.data())
     ///         .collect::<Vec<i32>>(),
     ///     vec![3, 4, 2]);
+    /// assert_eq!(
+    ///     *tree.get(two_id).unwrap().parent().unwrap().first_child().unwrap()
+    ///         .data(),
+    ///     3);
+    /// assert_eq!(
+    ///     *tree.get(two_id).unwrap().parent().unwrap().last_child().unwrap()
+    ///         .data(),
+    ///     2);
     /// assert!(!tree.get_mut(two_id).unwrap().to_last_sibling());
     /// assert_eq!(
     ///     tree.root().unwrap().children().map(|child_ref| *child_ref.data())
     ///         .collect::<Vec<i32>>(),
     ///     vec![3, 4, 2]);
+    /// assert_eq!(
+    ///     *tree.get(two_id).unwrap().parent().unwrap().first_child().unwrap()
+    ///         .data(),
+    ///     3);
+    /// assert_eq!(
+    ///     *tree.get(two_id).unwrap().parent().unwrap().last_child().unwrap()
+    ///         .data(),
+    ///     2);
     /// ```
     pub fn to_last_sibling(&mut self) -> bool {
         if let Some(parent_id) = self.parent().map(|parent| parent.node_id()) {
@@ -592,11 +656,27 @@ impl<'a, T> NodeMut<'a, T> {
     ///     tree.root().unwrap().children().map(|child_ref| *child_ref.data())
     ///         .collect::<Vec<i32>>(),
     ///     vec![4, 2, 3]);
+    /// assert_eq!(
+    ///     *tree.get(four_id).unwrap().parent().unwrap().first_child().unwrap()
+    ///         .data(),
+    ///     4);
+    /// assert_eq!(
+    ///     *tree.get(four_id).unwrap().parent().unwrap().last_child().unwrap()
+    ///         .data(),
+    ///     3);
     /// assert!(!tree.get_mut(four_id).unwrap().to_first_sibling());
     /// assert_eq!(
     ///     tree.root().unwrap().children().map(|child_ref| *child_ref.data())
     ///         .collect::<Vec<i32>>(),
     ///     vec![4, 2, 3]);
+    /// assert_eq!(
+    ///     *tree.get(four_id).unwrap().parent().unwrap().first_child().unwrap()
+    ///         .data(),
+    ///     4);
+    /// assert_eq!(
+    ///     *tree.get(four_id).unwrap().parent().unwrap().last_child().unwrap()
+    ///         .data(),
+    ///     3);
     /// ```
     pub fn to_first_sibling(&mut self) -> bool {
         if let Some(parent_id) = self.parent().map(|parent| parent.node_id()) {

--- a/src/node/node_mut.rs
+++ b/src/node/node_mut.rs
@@ -568,7 +568,7 @@ impl<'a, T> NodeMut<'a, T> {
     ///     tree.root().unwrap().children().map(|child_ref| *child_ref.data())
     ///         .collect::<Vec<i32>>(),
     ///     vec![2, 3, 4]);
-    /// assert!(tree.get_mut(two_id).unwrap().to_last_sibling());
+    /// assert!(tree.get_mut(two_id).unwrap().make_last_sibling());
     /// assert_eq!(
     ///     tree.root().unwrap().children().map(|child_ref| *child_ref.data())
     ///         .collect::<Vec<i32>>(),
@@ -581,7 +581,7 @@ impl<'a, T> NodeMut<'a, T> {
     ///     *tree.get(two_id).unwrap().parent().unwrap().last_child().unwrap()
     ///         .data(),
     ///     2);
-    /// assert!(!tree.get_mut(two_id).unwrap().to_last_sibling());
+    /// assert!(!tree.get_mut(two_id).unwrap().make_last_sibling());
     /// assert_eq!(
     ///     tree.root().unwrap().children().map(|child_ref| *child_ref.data())
     ///         .collect::<Vec<i32>>(),
@@ -595,7 +595,7 @@ impl<'a, T> NodeMut<'a, T> {
     ///         .data(),
     ///     2);
     /// ```
-    pub fn to_last_sibling(&mut self) -> bool {
+    pub fn make_last_sibling(&mut self) -> bool {
         if let Some(parent_id) = self.parent().map(|parent| parent.node_id()) {
             let node_id = self.node_id();
             let prev_id = self.tree.get_node_prev_sibling_id(node_id);
@@ -651,7 +651,7 @@ impl<'a, T> NodeMut<'a, T> {
     ///     tree.root().unwrap().children().map(|child_ref| *child_ref.data())
     ///         .collect::<Vec<i32>>(),
     ///     vec![2, 3, 4]);
-    /// assert!(tree.get_mut(four_id).unwrap().to_first_sibling());
+    /// assert!(tree.get_mut(four_id).unwrap().make_first_sibling());
     /// assert_eq!(
     ///     tree.root().unwrap().children().map(|child_ref| *child_ref.data())
     ///         .collect::<Vec<i32>>(),
@@ -664,7 +664,7 @@ impl<'a, T> NodeMut<'a, T> {
     ///     *tree.get(four_id).unwrap().parent().unwrap().last_child().unwrap()
     ///         .data(),
     ///     3);
-    /// assert!(!tree.get_mut(four_id).unwrap().to_first_sibling());
+    /// assert!(!tree.get_mut(four_id).unwrap().make_first_sibling());
     /// assert_eq!(
     ///     tree.root().unwrap().children().map(|child_ref| *child_ref.data())
     ///         .collect::<Vec<i32>>(),
@@ -678,7 +678,7 @@ impl<'a, T> NodeMut<'a, T> {
     ///         .data(),
     ///     3);
     /// ```
-    pub fn to_first_sibling(&mut self) -> bool {
+    pub fn make_first_sibling(&mut self) -> bool {
         if let Some(parent_id) = self.parent().map(|parent| parent.node_id()) {
             let node_id = self.node_id();
             let prev_id = self.tree.get_node_prev_sibling_id(node_id);

--- a/src/node/node_ref.rs
+++ b/src/node/node_ref.rs
@@ -18,6 +18,25 @@ impl<'a, T> NodeRef<'a, T> {
     }
 
     ///
+    /// Returns the `NodeId` that identifies this `Node` in the tree.
+    ///
+    /// ```
+    /// use slab_tree::tree::TreeBuilder;
+    ///
+    /// let mut tree = TreeBuilder::new().with_root(1).build();
+    /// let root_id = tree.root_id().expect("root doesn't exist?");
+    /// let root = tree.root_mut().expect("root doesn't exist?");
+    ///
+    /// let root_id_again = root.as_ref().node_id();
+    ///
+    /// assert_eq!(root_id_again, root_id);
+    /// ```
+    ///
+    pub fn node_id(&self) -> NodeId {
+        self.node_id
+    }
+
+    ///
     /// Returns a reference to the data contained by the given `Node`.
     ///
     /// ```


### PR DESCRIPTION
I'm currently using id_tree for a GUI and wanted to use sibling order to determine draw order, so I also needed to be able to re-arrange this order as needed. I figured it would be a good time to migrate to slab_tree and add the code here instead.